### PR TITLE
Add `SmallArray`

### DIFF
--- a/crates/solver_graph/src/helpers.rs
+++ b/crates/solver_graph/src/helpers.rs
@@ -1,5 +1,6 @@
 use crate::graph::{Edge, Edges, Graph, Nodes};
 
+#[macro_export]
 /// Use `graph![nodes, edges]` to create a `Graph`.
 ///
 /// ```rust
@@ -9,7 +10,6 @@ use crate::graph::{Edge, Edges, Graph, Nodes};
 /// let edges = edges(vec![Some(vec![edge(0, 1), edge(0, 2)]), Some(vec![edge(1, 2)]), None]);
 /// let graph = graph![nodes, edges];
 /// ```
-#[macro_export]
 macro_rules! graph {
     ($nodes:expr, $edges:expr) => {{
         $crate::graph::graph($nodes, $edges)
@@ -34,7 +34,10 @@ where
     T: Copy,
     T: Default,
 {
-    graph.edges().get(index).map(|edges| edges.iter().map(|e| &e.to).collect())
+    graph
+        .edges()
+        .get(index)
+        .map(|edges| edges.iter().map(|e| &e.to).collect())
 }
 
 /// The `Nodes` struct composes `Node` data.

--- a/crates/solver_graph/src/lib.rs
+++ b/crates/solver_graph/src/lib.rs
@@ -1,6 +1,7 @@
 mod graph;
 mod helpers;
 mod ops;
+mod small_array;
 
 #[cfg(test)]
 mod test_fixtures {

--- a/crates/solver_graph/src/small_array.rs
+++ b/crates/solver_graph/src/small_array.rs
@@ -1,0 +1,102 @@
+use std::ops::Deref;
+
+/// The `Sort` trait defines implementations for sortable data strucutres.
+trait Sort<T> {
+    fn sorted(&self, sorting: Sorting) -> Self;
+}
+
+#[derive(Default)]
+/// The `Sorting` enum provides different variants useful for describing how to sort an array.
+enum Sorting {
+    #[default]
+    Ascend,
+    Descend,
+}
+
+/// The `Replace` trait defines implementations for replacing data in arrays.
+trait Replace<T> {
+    fn replace(&self, index: usize, value: T) -> Self; // TODO: Might need to be &self -> Self
+}
+
+#[derive(Debug, Clone)]
+/// `SmallArray` is a compact array data structure for optimizing small graph problem search times.
+///
+/// ```rust
+/// use solver_graph::SmallArray;
+///
+/// let arr = SmallArray::Five([0; 5]).sorted(Sorting::Ascend);
+/// ```
+pub enum SmallArray<T> {
+    Empty,
+    One([T; 1]),
+    Five([T; 5]),
+    Ten([T; 10]),
+    Mutable(Vec<T>),
+}
+
+impl<T> SmallArray<T> {
+    fn as_slice(&self) -> &[T] {
+        match self {
+            Self::Empty => &[],
+            Self::One(v) => v,
+            Self::Five(v) => v,
+            Self::Ten(v) => v,
+            Self::Mutable(v) => v,
+        }
+    }
+}
+
+impl<T: Copy + Default> Sort<T> for SmallArray<T> {
+    fn sorted(&self, _sorting: Sorting) -> Self {
+        unimplemented!()
+    }
+}
+
+impl<T: Copy + Default> Replace<T> for SmallArray<T> {
+    fn replace(&self, _index: usize, _value: T) -> Self {
+        unimplemented!()
+    }
+}
+
+impl<T> Default for SmallArray<T> {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+impl<T> Deref for SmallArray<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a SmallArray<T> {
+    type Item = &'a T;
+
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<T: Eq> Eq for SmallArray<T> {}
+
+impl<T: PartialEq> PartialEq for SmallArray<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_small_array() {
+        let arr = SmallArray::Five([0; 5]).sorted(Sorting::Ascend);
+        assert_ne!(arr, SmallArray::Five([0; 5]))
+    }
+}

--- a/crates/solver_graph/src/small_array.rs
+++ b/crates/solver_graph/src/small_array.rs
@@ -1,4 +1,4 @@
-use std::ops::{Deref};
+use std::ops::Deref;
 
 /// The `Sort` trait defines implementations for sortable data strucutres.
 trait Sort<T> {
@@ -16,6 +16,7 @@ enum Sorting {
 
 #[derive(Debug, Clone)]
 /// `SmallArray` is a compact array data structure for optimizing small graph problem search times.
+/// The goal is to implement constraint-based sorting for `SmallArray`s.
 ///
 /// ```rust
 /// use solver_graph::SmallArray;
@@ -34,10 +35,10 @@ impl<T> SmallArray<T> {
     fn as_slice(&self) -> &[T] {
         match self {
             Self::Empty => &[],
-            Self::One(v) => v,
-            Self::Five(v) => v,
-            Self::Ten(v) => v,
-            Self::Dynamic(v) => v,
+            Self::One(it) => it,
+            Self::Five(it) => it,
+            Self::Ten(it) => it,
+            Self::Dynamic(it) => it,
         }
     }
 
@@ -46,14 +47,13 @@ impl<T> SmallArray<T> {
     }
 }
 
-/// The `Replace` trait defines implementations for replacing data in arrays.
-trait Replace<T> {
-    fn replace(self, index: usize, value: T) -> Self; // TODO: Might need to be &self -> Self
-}
-
 impl<T: Copy + Default + PartialOrd + Ord> Sort<T> for SmallArray<T> {
     fn sorted(&mut self, sorting: Sorting) -> &mut Self {
-        sort_small_array(self, sorting)
+        if self.empty() {
+            self
+        } else {
+            sort_small_array(self, sorting)
+        }
     }
 }
 
@@ -63,85 +63,32 @@ fn sort_small_array<T: PartialOrd + Ord>(
     sorting: Sorting,
 ) -> &mut SmallArray<T> {
     match arr {
-        SmallArray::Five(it) => {
-            sort_five(it, sorting);
-            arr
-        }
-        SmallArray::Ten(it) => {
-            sort_ten(it, sorting);
-            arr
-        }
-        SmallArray::Dynamic(it) => {
-            sort_dynamic(it, sorting);
-            arr
-        }
-        _ => arr,
+        SmallArray::Five(it) => sort_five(it, sorting),
+        SmallArray::Ten(it) => sort_ten(it, sorting),
+        SmallArray::Dynamic(it) => sort_dynamic(it, sorting),
+        _ => (),
     }
+    arr
 }
 
 fn sort_five<T: PartialOrd + Ord>(it: &mut [T; 5], sorting: Sorting) {
     match sorting {
-        Sorting::Ascend => {
-            it.sort();
-        }
-        _ => unimplemented!(),
+        Sorting::Ascend => it.sort(),
+        Sorting::Descend => it.reverse(),
     }
 }
 
 fn sort_ten<T: PartialOrd + Ord>(it: &mut [T; 10], sorting: Sorting) {
     match sorting {
         Sorting::Ascend => it.sort(),
-        _ => unimplemented!(),
+        Sorting::Descend => it.reverse(),
     }
 }
 
 fn sort_dynamic<T: PartialOrd + Ord>(it: &mut Vec<T>, sorting: Sorting) {
     match sorting {
         Sorting::Ascend => it.sort(),
-        _ => unimplemented!(),
-    }
-}
-
-/// TODO: Can I do unsafe { ... }?
-impl<T: Copy + Default> Replace<T> for SmallArray<T> {
-    fn replace(self, index: usize, value: T) -> Self {
-        match self {
-            Self::Empty => self,
-            Self::One(mut it) => {
-                replace_with_one(&mut it, index, value);
-                self
-            }
-            Self::Five(mut it) => {
-                replace_with_five(&mut it, index, value);
-                self
-            }
-            Self::Ten(mut it) => {
-                replace_with_ten(&mut it, index, value);
-                self
-            }
-            Self::Dynamic(mut it) => {
-                it.remove(index);
-                it.insert(index, value);
-                Self::Dynamic(it)
-            }
-        }
-    }
-}
-
-fn replace_with_one<T: Copy + Default>(it: &mut [T; 1], index: usize, value: T) {
-    it[index] = value
-}
-
-fn replace_with_five<T: Copy + Default>(_it: &mut [T; 5], _index: usize, _value: T) {
-    todo!()
-}
-fn replace_with_ten<T: Copy + Default>(_it: &mut [T; 10], _index: usize, _value: T) {
-    todo!()
-}
-
-impl<T> Default for SmallArray<T> {
-    fn default() -> Self {
-        Self::Empty
+        Sorting::Descend => it.reverse(),
     }
 }
 
@@ -182,19 +129,16 @@ mod tests {
     }
 
     #[test]
-    fn test_replace() {
-        let arr = SmallArray::One([1]).replace(0, 1);
-        assert_eq!(arr, SmallArray::One([1]))
-    }
-
-    #[test]
     fn test_sorted() {
         let mut arr = SmallArray::Five([1, 2, 3, 4, 5]);
-        // let mut desc = arr.clone();
+        let mut desc = arr.clone();
         assert_eq!(
             arr.sorted(Sorting::Ascend),
             &mut SmallArray::Five([1, 2, 3, 4, 5])
         );
-        // assert_eq!(desc.sorted(Sorting::Descend), &mut SmallArray::Five([5, 4, 3, 2, 1]));
+        assert_eq!(
+            desc.sorted(Sorting::Descend),
+            &mut SmallArray::Five([5, 4, 3, 2, 1])
+        );
     }
 }

--- a/crates/solver_graph/src/small_array.rs
+++ b/crates/solver_graph/src/small_array.rs
@@ -12,7 +12,10 @@ enum Sorting {
     #[default]
     Ascend,
     Descend,
+    Constraint(Constraint),
 }
+
+struct Constraint;
 
 #[derive(Debug, Clone)]
 /// `SmallArray` is a compact array data structure for optimizing small graph problem search times.
@@ -63,32 +66,19 @@ fn sort_small_array<T: PartialOrd + Ord>(
     sorting: Sorting,
 ) -> &mut SmallArray<T> {
     match arr {
-        SmallArray::Five(it) => sort_five(it, sorting),
-        SmallArray::Ten(it) => sort_ten(it, sorting),
-        SmallArray::Dynamic(it) => sort_dynamic(it, sorting),
+        SmallArray::Five(it) => sort(it, sorting),
+        SmallArray::Ten(it) => sort(it, sorting),
+        SmallArray::Dynamic(it) => sort(it, sorting),
         _ => (),
     }
     arr
 }
 
-fn sort_five<T: PartialOrd + Ord>(it: &mut [T; 5], sorting: Sorting) {
+fn sort<T: PartialOrd + Ord>(it: &mut [T], sorting: Sorting) {
     match sorting {
         Sorting::Ascend => it.sort(),
         Sorting::Descend => it.reverse(),
-    }
-}
-
-fn sort_ten<T: PartialOrd + Ord>(it: &mut [T; 10], sorting: Sorting) {
-    match sorting {
-        Sorting::Ascend => it.sort(),
-        Sorting::Descend => it.reverse(),
-    }
-}
-
-fn sort_dynamic<T: PartialOrd + Ord>(it: &mut Vec<T>, sorting: Sorting) {
-    match sorting {
-        Sorting::Ascend => it.sort(),
-        Sorting::Descend => it.reverse(),
+        _ => (),
     }
 }
 

--- a/crates/solver_graph/src/small_array.rs
+++ b/crates/solver_graph/src/small_array.rs
@@ -7,15 +7,11 @@ trait Sort<T> {
 
 #[derive(Default)]
 /// The `Sorting` enum provides different variants useful for describing how to sort an array.
+/// TODO: Constraints(vec![Constraint])
 enum Sorting {
     #[default]
     Ascend,
     Descend,
-}
-
-/// The `Replace` trait defines implementations for replacing data in arrays.
-trait Replace<T> {
-    fn replace(&self, index: usize, value: T) -> Self; // TODO: Might need to be &self -> Self
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +40,15 @@ impl<T> SmallArray<T> {
             Self::Mutable(v) => v,
         }
     }
+
+    fn empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+}
+
+/// The `Replace` trait defines implementations for replacing data in arrays.
+trait Replace<T> {
+    fn replace(self, index: usize, value: T) -> Self; // TODO: Might need to be &self -> Self
 }
 
 impl<T: Copy + Default> Sort<T> for SmallArray<T> {
@@ -53,8 +58,15 @@ impl<T: Copy + Default> Sort<T> for SmallArray<T> {
 }
 
 impl<T: Copy + Default> Replace<T> for SmallArray<T> {
-    fn replace(&self, _index: usize, _value: T) -> Self {
-        unimplemented!()
+    fn replace(self, index: usize, value: T) -> Self {
+        if self.empty() {
+            self
+        } else {
+            let mut arr = self.as_slice().to_vec();
+            arr.remove(index);
+            arr.insert(index, value);
+            Self::Mutable(arr)
+        }
     }
 }
 
@@ -96,7 +108,13 @@ mod tests {
 
     #[test]
     fn test_small_array() {
-        let arr = SmallArray::Five([0; 5]).sorted(Sorting::Ascend);
-        assert_ne!(arr, SmallArray::Five([0; 5]))
+        let arr = SmallArray::Five([0; 5]);
+        assert_ne!(arr, SmallArray::Five([1; 5]))
+    }
+
+    #[test]
+    fn test_replace() {
+        let arr = SmallArray::One([1]).replace(0, 1);
+        assert_eq!(arr, SmallArray::One([1]))
     }
 }


### PR DESCRIPTION
Experimenting with implementing `sort` using a `SmallArray` strategy. Instead of #43 it might be faster to just use small arrays of data for my specific use-case.

The graph problems I'd like to solve can be constrained well. I'd want to solve many graphs in parallel. The number of edges required for each `Node` should be limited for the graphs I'd traverse.

<img width="725" alt="image" src="https://github.com/cnpryer/solver/assets/14341145/12efcdcd-4a18-45d8-b454-c196f1f17bf7">
